### PR TITLE
activate PDF generation in project-template #145

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ target/
 ehthumbs.db
 Thumbs.db
 
+/.classpath
+/.project

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,16 @@
 
     <properties>
         <swagger2markup.version>1.0.0</swagger2markup.version>
+        
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
+        <jruby.version>1.7.21</jruby.version>
+        
         <swagger.input>${project.basedir}/src/docs/swagger/swagger_petstore.yaml</swagger.input>
         <asciidoctor.input.directory>${project.basedir}/src/docs/asciidoc</asciidoctor.input.directory>
         <generated.asciidoc.directory>${project.build.directory}/asciidoc</generated.asciidoc.directory>
         <asciidoctor.html.output.directory>${project.build.directory}/asciidoc/html</asciidoctor.html.output.directory>
         <asciidoctor.pdf.output.directory>${project.build.directory}/asciidoc/pdf</asciidoctor.pdf.output.directory>
+        
     </properties>
 
     <pluginRepositories>
@@ -74,6 +79,19 @@
                         <artifactId>asciidoctorj-pdf</artifactId>
                         <version>1.5.0-alpha.10.1</version>
                     </dependency>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>${asciidoctorj.version}</version>
+                    </dependency>
+                    
                 </dependencies>
                 <!-- Configure generic document generation settings -->
                 <configuration>
@@ -104,7 +122,7 @@
                             <outputDirectory>${asciidoctor.html.output.directory}</outputDirectory>
                         </configuration>
                     </execution>
-                    <!--
+                    
                     <execution>
                         <id>output-pdf</id>
                         <phase>generate-resources</phase>
@@ -116,7 +134,7 @@
                             <outputDirectory>${asciidoctor.pdf.output.directory}</outputDirectory>
                         </configuration>
                     </execution>
-                    -->
+                   
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
Activate the pdf generation and add the missing dependencies for jruby and asciidoctorj (see https://github.com/asciidoctor/asciidoctor-maven-examples/tree/master/asciidoctor-pdf-example).
