### PR TITLE
Improve the docs about including your own spec

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,8 @@ This is a Swagger2Markup Maven template project which uses the swagger2markup-ma
 
 === Swagger Specification
 
-Copy your Swagger Specification (JSON or YAML) file into the folder `src/docs/swagger`.
+. Copy your Swagger Specification (JSON or YAML) file into the folder `src/docs/swagger`
+. Modify the `pom.xml` `properties.swagger.input` to point at the copied specification
 
 === Add hand-written content
 


### PR DESCRIPTION
There was no information about having to re-point the pom.xml at the specification copied into the project.