### PR TITLE
Upgraded asciidoctorj, asciidoctorj-pdf & asciidoctor-maven-plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,16 +12,16 @@
         <swagger2markup.version>1.3.1</swagger2markup.version>
         <swagger2markup.plugin.version>1.3.2</swagger2markup.plugin.version>
         <swagger2markup.extension.version>1.3.1</swagger2markup.extension.version>
-        
-        <asciidoctorj.version>1.5.4</asciidoctorj.version>
-        <jruby.version>1.7.21</jruby.version>
-        
+
+        <asciidoctorj.version>1.5.5</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
+        <jruby.version>9.1.8.0</jruby.version>
+
         <swagger.input>${project.basedir}/src/docs/swagger/swagger_petstore.yaml</swagger.input>
         <asciidoctor.input.directory>${project.basedir}/src/docs/asciidoc</asciidoctor.input.directory>
         <generated.asciidoc.directory>${project.build.directory}/asciidoc</generated.asciidoc.directory>
         <asciidoctor.html.output.directory>${project.build.directory}/asciidoc/html</asciidoctor.html.output.directory>
         <asciidoctor.pdf.output.directory>${project.build.directory}/asciidoc/pdf</asciidoctor.pdf.output.directory>
-        
     </properties>
 
     <pluginRepositories>
@@ -86,13 +86,13 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.3</version>
+                <version>1.5.5</version>
                 <!-- Include Asciidoctor PDF for pdf generation -->
                 <dependencies>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.10.1</version>
+                        <version>${asciidoctorj.pdf.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -106,7 +106,6 @@
                         <artifactId>asciidoctorj</artifactId>
                         <version>${asciidoctorj.version}</version>
                     </dependency>
-                    
                 </dependencies>
                 <!-- Configure generic document generation settings -->
                 <configuration>
@@ -137,7 +136,7 @@
                             <outputDirectory>${asciidoctor.html.output.directory}</outputDirectory>
                         </configuration>
                     </execution>
-                    
+
                     <execution>
                         <id>output-pdf</id>
                         <phase>generate-resources</phase>
@@ -149,7 +148,6 @@
                             <outputDirectory>${asciidoctor.pdf.output.directory}</outputDirectory>
                         </configuration>
                     </execution>
-                   
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
This PR just upgrades the version of asciidoctorj, asciidoctorj-pdf & asciidoctor-maven-plugin to the current versions.
The JRuby version has been upgraded to 9.1.8.0 as required since asciidoctoj-pdf alpha.14 (see https://github.com/asciidoctor/asciidoctorj/releases/tag/v1.5.5) .


Tested on Maven 3.5.0, Java 1.8.0_131, Windows 7.